### PR TITLE
fix: minor typo in inline pragma

### DIFF
--- a/src/tapa/xilinx/hls/stream.h
+++ b/src/tapa/xilinx/hls/stream.h
@@ -80,7 +80,7 @@ class istream {
   }
 
   T read() {
-#pragma HLS inlinemmap
+#pragma HLS inline
     return _.read().val;
   }
 


### PR DESCRIPTION
There is a typo in src/tapa/xilinx/hls/stream.h as far as I can see. It says `#pragma HLS inlinemmap` instead of `#pragma HLS inline`.